### PR TITLE
added nested query to deleteTag to scrub receipts_tags table as well

### DIFF
--- a/manageTags.js
+++ b/manageTags.js
@@ -73,11 +73,17 @@ module.exports = (app) => {
             success: false
         };
         if (userId){
-            connection.query("DELETE FROM tags WHERE tags.ID = ? AND tags.userId = ?;",
+            connection.query(`DELETE FROM tags WHERE tags.ID = ? AND tags.userId = ?;`,
                             [tagId, userId],
                             (error, result) => {
                                 if (error) throw error;
                                 if (result.affectedRows > 0){
+                                    connection.query(`DELETE FROM receipts_tags WHERE receipts_tags.tagId = ?`,
+                                                    [tagId],
+                                                    (error) => {
+                                                        if (error) throw error;
+                                                    }
+                                    );
                                     output.success = true;
                                     return response.status(200).send(output);
                                 }


### PR DESCRIPTION
later, this should be done with one query, if possible. this was only possible using a inner join with tags and receipt_tags...but did not work if the tag id wasn't in both tables. the problem with this is the scenario where the user deletes a tag that isn't used. it would never be deleted.